### PR TITLE
Fix schema validation and missing import errors

### DIFF
--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Brain, Sparkles, Target, Clock, ArrowRight, History, TrendingUp, Eye, Trash2 } from 'lucide-react';
-import { formatAssessmentDate } from '@/lib/assessment-storage';
+import { formatAssessmentDate } from '@/lib/date-utils';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { AssessmentResultSkeleton } from '@/components/loading-skeleton';
@@ -184,7 +184,7 @@ export default function AssessmentsPage() {
                         <div className="flex-1">
                           <div className="flex items-center gap-3 mb-2">
                             <span className="text-sm font-bold text-gray-600">
-                              {formatAssessmentDate(new Date(result.completedAt).toISOString())}
+                              {formatAssessmentDate(result.completedAt)}
                             </span>
                             <span className="px-2 py-1 bg-brutal-green text-black text-xs font-bold border-2 border-black">
                               {Math.round(topMatch?.matchPercentage || 0)}% Match

--- a/app/dashboard/student/page.tsx
+++ b/app/dashboard/student/page.tsx
@@ -15,7 +15,7 @@ import {
   User,
   BookOpen,
 } from "lucide-react";
-import { formatAssessmentDate } from "@/lib/assessment-storage";
+import { formatAssessmentDate } from "@/lib/date-utils";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { useConvexAuth } from "@/lib/hooks/useConvexAuth";

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -70,30 +70,30 @@ export default defineSchema({
     views: v.number(),
     saves: v.number(),
 
-    // Assessment matching metadata (RIASEC system)
-    interestProfile: v.object({
+    // Assessment matching metadata (RIASEC system) - Optional for backward compatibility
+    interestProfile: v.optional(v.object({
       realistic: v.number(),      // 0-100 scale
       investigative: v.number(),  // 0-100 scale
       artistic: v.number(),       // 0-100 scale
       social: v.number(),         // 0-100 scale
       enterprising: v.number(),   // 0-100 scale
       conventional: v.number(),   // 0-100 scale
-    }),
+    })),
 
-    valueProfile: v.object({
+    valueProfile: v.optional(v.object({
       impact: v.number(),         // 0-100 scale
       income: v.number(),         // 0-100 scale
       autonomy: v.number(),       // 0-100 scale
       balance: v.number(),        // 0-100 scale
       growth: v.number(),         // 0-100 scale
       stability: v.number(),      // 0-100 scale
-    }),
+    })),
 
-    workEnvironment: v.object({
+    workEnvironment: v.optional(v.object({
       teamSize: v.string(),       // 'solo' | 'independent' | 'small' | 'large' | 'leader' | 'minimal'
       pace: v.string(),           // 'steady' | 'moderate' | 'intense' | 'flexible' | 'deadline-driven' | 'predictable'
       structure: v.optional(v.string()), // 'flexible' | 'balanced' | 'structured' (optional for backward compatibility)
-    }),
+    })),
   })
     .index("by_category", ["category"])
     .index("by_title", ["title"]),

--- a/lib/assessment-algorithm.ts
+++ b/lib/assessment-algorithm.ts
@@ -43,9 +43,9 @@ export interface Career {
   category: string;
   salaryMin: number;
   salaryMax: number;
-  interestProfile: RIASECScore;
-  valueProfile: ValueScore;
-  workEnvironment: {
+  interestProfile?: RIASECScore;
+  valueProfile?: ValueScore;
+  workEnvironment?: {
     teamSize: string;
     pace: string;
   };
@@ -123,6 +123,11 @@ function generateReasons(
   career: Career
 ): string[] {
   const reasons: string[] = [];
+
+  // Skip if no metadata
+  if (!career.interestProfile || !career.valueProfile || !career.workEnvironment) {
+    return ['Career assessment data is being updated'];
+  }
 
   // RIASEC alignment
   const studentTop = getTop3RIASEC(studentProfile.riasec);
@@ -217,6 +222,19 @@ export function calculateCareerMatch(
   studentProfile: AssessmentProfile,
   career: Career
 ): MatchResult {
+  // Skip careers without metadata
+  if (!career.interestProfile || !career.valueProfile || !career.workEnvironment) {
+    return {
+      careerId: career._id,
+      matchPercentage: 0,
+      interestScore: 0,
+      valueScore: 0,
+      environmentScore: 0,
+      topRIASEC: getTop3RIASEC(studentProfile.riasec),
+      matchReasons: ['This career needs updated assessment data'],
+    };
+  }
+
   // 1. RIASEC Interest Match (50% weight)
   const interestMatch = cosineSimilarity(
     studentProfile.riasec,

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Format assessment date for display
+ */
+export function formatAssessmentDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffInMs = now.getTime() - date.getTime();
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+
+  // Less than 1 day ago
+  if (diffInDays === 0) {
+    const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+    if (diffInHours === 0) {
+      const diffInMinutes = Math.floor(diffInMs / (1000 * 60));
+      return diffInMinutes <= 1 ? 'Just now' : `${diffInMinutes} minutes ago`;
+    }
+    return diffInHours === 1 ? '1 hour ago' : `${diffInHours} hours ago`;
+  }
+
+  // Less than 7 days ago
+  if (diffInDays < 7) {
+    return diffInDays === 1 ? 'Yesterday' : `${diffInDays} days ago`;
+  }
+
+  // Less than 30 days ago
+  if (diffInDays < 30) {
+    const weeks = Math.floor(diffInDays / 7);
+    return weeks === 1 ? '1 week ago' : `${weeks} weeks ago`;
+  }
+
+  // More than 30 days ago - show actual date
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}


### PR DESCRIPTION
Fixes:
1. Made career metadata fields optional in schema for backward compatibility
   - interestProfile, valueProfile, workEnvironment now optional
   - Allows existing careers in DB to work without metadata
   - Assessment algorithm gracefully handles missing metadata

2. Created date-utils.ts to replace deleted assessment-storage.ts
   - formatAssessmentDate() function for displaying relative dates
   - Used in assessments page and student dashboard

3. Updated assessment algorithm to skip careers without metadata
   - Returns 0% match with message for careers needing updates
   - generateReasons() handles missing data gracefully

All errors resolved. Schema validation passes, app compiles successfully.